### PR TITLE
Add Solidity syntax highlight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.vy linguist-language=Python
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Update `.gitattributes` to enable Solidity syntax highlight on GitHub.