### PR TITLE
comment typo in Strategy.sol

### DIFF
--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -143,7 +143,7 @@ contract Strategy is BaseStrategy {
     }
 
     // Override this to add all tokens/tokenized positions this contract manages
-    // on a *persistant* basis (e.g. not just for swapping back to want ephemerally)
+    // on a *persistent* basis (e.g. not just for swapping back to want ephemerally)
     // NOTE: Do *not* include `want`, already included in `sweep` below
     //
     // Example:


### PR DESCRIPTION
This fixes a typo in Strategy.sol: "persistant" -> "persistent"