### PR TITLE
fix: Reduce duplicate import

### DIFF
--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -10,10 +10,13 @@ import {
     BaseStrategy,
     StrategyParams
 } from "@yearnvaults/contracts/BaseStrategy.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import {
+    SafeERC20,
+    SafeMath,
+    IERC20,
+    Address
+} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
 
 // Import interfaces for many popular DeFi projects, or add your own!
 //import "../interfaces/<protocol>/<Interface>.sol";


### PR DESCRIPTION
This PR removes the unnecessary imports of  SafeMath, IERC20, Address instead imports it from the SafeERC20 import as SafeERC20 already imports the same.