### PR TITLE
test: add more boilerplate tests

### DIFF
--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -3,5 +3,14 @@
 #       Show that nothing is lost!
 
 
-def test_migration():
-    pass
+def test_migration(token, vault, strategy, amount, Strategy, strategist, gov):
+    # Deposit to the vault and harvest
+    token.approve(vault.address, amount, {"from": gov})
+    vault.deposit(amount, {"from": gov})
+    strategy.harvest()
+    assert token.balanceOf(strategy.address) == amount
+
+    # migrate to a new strategy
+    new_strategy = strategist.deploy(Strategy, vault)
+    strategy.migrate(new_strategy.address, {"from": gov})
+    assert token.balanceOf(new_strategy.address) == amount

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -30,3 +30,39 @@ def test_emergency_exit(accounts, token, vault, strategy, strategist, amount):
     strategy.setEmergencyExit()
     strategy.harvest()
     assert token.balanceOf(strategy.address) < amount
+
+
+def test_profitable_harvest(accounts, token, vault, strategy, strategist, amount):
+    # Deposit to the vault
+    token.approve(vault.address, amount, {"from": accounts[0]})
+    vault.deposit(amount, {"from": accounts[0]})
+    assert token.balanceOf(vault.address) == amount
+
+    # harvest
+    strategy.harvest()
+    assert token.balanceOf(strategy.address) == amount
+
+    # You should test that the harvest method is capable of making a profit.
+    # TODO: uncomment the following lines.
+    # strategy.harvest()
+    # chain.sleep(3600 * 24)
+    # assert token.balanceOf(strategy.address) > amount
+
+
+def test_change_debt(gov, token, vault, strategy, strategist, amount):
+    # Deposit to the vault and harvest
+    token.approve(vault.address, amount, {"from": gov})
+    vault.deposit(amount, {"from": gov})
+    vault.updateStrategyDebtRatio(strategy.address, 5_000, {"from": gov})
+    strategy.harvest()
+
+    assert token.balanceOf(strategy.address) == amount / 2
+
+    vault.updateStrategyDebtRatio(strategy.address, 10_000, {"from": gov})
+    strategy.harvest()
+    assert token.balanceOf(strategy.address) == amount
+
+    # In order to pass this tests, you will need to implement prepareReturn.
+    # TODO: uncomment the following lines.
+    # vault.updateStrategyDebtRatio(strategy.address, 5_000, {"from": gov})
+    # assert token.balanceOf(strategy.address) == amount / 2

--- a/tests/test_revoke.py
+++ b/tests/test_revoke.py
@@ -1,0 +1,24 @@
+def test_revoke_strategy_from_vault(token, vault, strategy, amount, gov):
+    # Deposit to the vault and harvest
+    token.approve(vault.address, amount, {"from": gov})
+    vault.deposit(amount, {"from": gov})
+    strategy.harvest()
+    assert token.balanceOf(strategy.address) == amount
+
+    # In order to pass this tests, you will need to implement prepareReturn.
+    # TODO: uncomment the following lines.
+    # vault.revokeStrategy(strategy.address, {"from": gov})
+    # strategy.harvest()
+    # assert token.balanceOf(vault.address) == amount
+
+
+def test_revoke_strategy_from_strategy(token, vault, strategy, amount, gov):
+    # Deposit to the vault and harvest
+    token.approve(vault.address, amount, {"from": gov})
+    vault.deposit(amount, {"from": gov})
+    strategy.harvest()
+    assert token.balanceOf(strategy.address) == amount
+
+    strategy.setEmergencyExit()
+    strategy.harvest()
+    assert token.balanceOf(vault.address) == amount


### PR DESCRIPTION
Adding tests for the following points:

- Profitable harvest 
- Revoke strategy and check that funds return to the vault
- Increase/decrease debt + harvest, and check that the strategy is working well
- Migration

Some tests contains TODO that should be completed by the strategist.

https://github.com/iearn-finance/brownie-strategy-mix/issues/14